### PR TITLE
Fix/resume jobs by stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cule filo - AI-powered restaurant search engine
+# Cule Filo - AI-powered restaurant search engine
 
 > Discover the top 3 restaurants serving your favorite food near you. Just enter your craving and location in our free AI-powered app, and start your culinary adventure today!. Our submittion to the [Cloudflare AI Challenge.](https://dev.to/devteam/join-us-for-the-cloudflare-ai-challenge-3000-in-prizes-5f99)
 

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -4,12 +4,12 @@ export default function Header() {
   return (
     <div className="my-4 flex flex-col items-center justify-center gap-2">
       <Link to="/" className="my-4">
-        <h1 className="text-6xl">Cule filo</h1>
+        <h1 className="text-6xl">Cule Filo</h1>
       </Link>
       <p className="text-justify text-gray-500">
-        Craving your favorite meal? Our AI-powered search makes it easy to find the top 3
-        restaurants serving it near you. Just enter the dish you're looking for and your
-        location, and let our intelligent algorithm do the rest. Whether it's a local
+        Craving your favorite meal? Our AI-powered search engine makes it easy to find the
+        top 3 restaurants serving it near you. Just enter the dish you're looking for and
+        your location, and let our intelligent algorithm do the rest. Whether it's a local
         specialty or a global delicacy, our free app will guide you to the perfect spot.
       </p>
     </div>

--- a/app/constants/job.ts
+++ b/app/constants/job.ts
@@ -10,4 +10,16 @@ export const ALL_SEARCH_JOB_STATES = Object.values(SearchJobState) as [
   ...SearchJobState[],
 ];
 
+export enum SearchJobStage {
+  Initial = 'initial',
+  Suggestions = 'suggestions',
+  Summarization = 'summarization',
+  Parsing = 'parsing',
+}
+
+export const ALL_SEARCH_JOB_STAGES = Object.values(SearchJobStage) as [
+  SearchJobStage,
+  ...SearchJobStage[],
+];
+
 export const DONE_JOB_MESSAGE = 'done';

--- a/app/constants/job.ts
+++ b/app/constants/job.ts
@@ -12,8 +12,7 @@ export const ALL_SEARCH_JOB_STATES = Object.values(SearchJobState) as [
 
 export enum SearchJobStage {
   Initial = 'initial',
-  Suggestions = 'suggestions',
-  Summarization = 'summarization',
+  PlacesFetched = 'placesFetched',
   Parsing = 'parsing',
 }
 

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -19,17 +19,17 @@ export function Layout({ children }: { children: React.ReactNode }) {
 
         <meta
           property="og:title"
-          content="Cule filo - AI-powered restaurant search engine"
+          content="Cule Filo - AI-powered restaurant search engine"
         />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://culefilo.pages.dev" />
-        <meta property="og:site_name" content="Cule filo" />
+        <meta property="og:site_name" content="Cule Filo" />
         <meta
           property="og:description"
           content="Discover the top 3 restaurants serving your favorite food near you. Just enter your craving and location in our free AI-powered app, and start your culinary adventure today!"
         />
 
-        <title>Cule filo - AI-powered restaurant search engine</title>
+        <title>Cule Filo - AI-powered restaurant search engine</title>
 
         <Meta />
         <Links />

--- a/app/schemas/job.ts
+++ b/app/schemas/job.ts
@@ -5,53 +5,6 @@ import { ALL_SEARCH_JOB_STAGES, ALL_SEARCH_JOB_STATES } from '~/constants/job';
 import { SearchSchema } from './search';
 import { PlaceLocationSchema, PlaceParsedSchema, PlaceSchema } from './place';
 
-const PlaceAPIResponseSchema = z.object({
-  id: z.string(),
-  formattedAddress: z.string(),
-  location: z.object({
-    latitude: z.number(),
-    longitude: z.number(),
-  }),
-  rating: z.number(),
-  googleMapsUri: z.string(),
-  priceLevel: z.enum(['FREE', 'INEXPENSIVE', 'MODERATE', 'EXPENSIVE', 'VERY_EXPENSIVE']),
-  userRatingCount: z.number(),
-  displayName: z.object({
-    text: z.string(),
-    languageCode: z.string(),
-  }),
-  currentOpeningHours: z
-    .object({
-      openNow: z.boolean(),
-      weekdayDescriptions: z.array(z.string()),
-    })
-    .optional(),
-  reviews: z
-    .array(
-      z.object({
-        text: z.object({
-          text: z.string(),
-          languageCode: z.string(),
-        }),
-      })
-    )
-    .optional(),
-  photos: z.array(
-    z.object({
-      name: z.string(),
-      widthPx: z.number(),
-      heightPx: z.number(),
-      authorAttributions: z.array(
-        z.object({
-          displayName: z.string(),
-          uri: z.string(),
-          photoUri: z.string(),
-        })
-      ),
-    })
-  ),
-});
-
 export const SearchJobSchema = z.object({
   input: SearchSchema.pick({
     favoriteMealName: true,
@@ -60,9 +13,10 @@ export const SearchJobSchema = z.object({
   location: PlaceLocationSchema,
   state: z.enum(ALL_SEARCH_JOB_STATES),
   stage: z.enum(ALL_SEARCH_JOB_STAGES),
-  allPlaces: z.record(PlaceAPIResponseSchema),
-  descriptions: z.array(z.object({ id: z.string(), description: z.string() })).optional(),
-  thumbnails: z.array(z.object({ id: z.string(), thumbnail: z.string() })).optional(),
+  placesFetched: z.record(z.any()),
+  descriptions: z.array(z.object({ id: z.string(), description: z.string() })),
+  thumbnails: z.array(z.object({ id: z.string(), thumbnail: z.string() })),
+  places: z.array(PlaceSchema).optional(),
   logs: z.array(z.string()).optional(),
   createdAt: z.number(),
 });

--- a/app/schemas/job.ts
+++ b/app/schemas/job.ts
@@ -1,9 +1,56 @@
 import { z } from 'zod';
 
-import { ALL_SEARCH_JOB_STATES } from '~/constants/job';
+import { ALL_SEARCH_JOB_STAGES, ALL_SEARCH_JOB_STATES } from '~/constants/job';
 
 import { SearchSchema } from './search';
 import { PlaceLocationSchema, PlaceParsedSchema, PlaceSchema } from './place';
+
+const PlaceAPIResponseSchema = z.object({
+  id: z.string(),
+  formattedAddress: z.string(),
+  location: z.object({
+    latitude: z.number(),
+    longitude: z.number(),
+  }),
+  rating: z.number(),
+  googleMapsUri: z.string(),
+  priceLevel: z.enum(['FREE', 'INEXPENSIVE', 'MODERATE', 'EXPENSIVE', 'VERY_EXPENSIVE']),
+  userRatingCount: z.number(),
+  displayName: z.object({
+    text: z.string(),
+    languageCode: z.string(),
+  }),
+  currentOpeningHours: z
+    .object({
+      openNow: z.boolean(),
+      weekdayDescriptions: z.array(z.string()),
+    })
+    .optional(),
+  reviews: z
+    .array(
+      z.object({
+        text: z.object({
+          text: z.string(),
+          languageCode: z.string(),
+        }),
+      })
+    )
+    .optional(),
+  photos: z.array(
+    z.object({
+      name: z.string(),
+      widthPx: z.number(),
+      heightPx: z.number(),
+      authorAttributions: z.array(
+        z.object({
+          displayName: z.string(),
+          uri: z.string(),
+          photoUri: z.string(),
+        })
+      ),
+    })
+  ),
+});
 
 export const SearchJobSchema = z.object({
   input: SearchSchema.pick({
@@ -12,7 +59,10 @@ export const SearchJobSchema = z.object({
   }),
   location: PlaceLocationSchema,
   state: z.enum(ALL_SEARCH_JOB_STATES),
-  places: z.array(PlaceSchema).optional(),
+  stage: z.enum(ALL_SEARCH_JOB_STAGES),
+  allPlaces: z.record(PlaceAPIResponseSchema),
+  descriptions: z.array(z.object({ id: z.string(), description: z.string() })).optional(),
+  thumbnails: z.array(z.object({ id: z.string(), thumbnail: z.string() })).optional(),
   logs: z.array(z.string()).optional(),
   createdAt: z.number(),
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "culefilo",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "sideEffects": false,
   "type": "module",


### PR DESCRIPTION
If the job fails we lost all the fetched and processed data, to avoid retrying from scratch a retry by checkpoints/stages is proposed.

A new button "Retry" will call the SSE again `/search/job/${jobId}`
The stages and metadata is stored in memory + KV

<img width="880" alt="image" src="https://github.com/sjdonado/culefilo/assets/27580836/d8ba6bf8-4871-49a2-b8d9-15cffed8a0d9">


Likely mitigates this issue:
<img width="1728" alt="image" src="https://github.com/sjdonado/culefilo/assets/27580836/5cd56e0b-f927-4d46-8ec9-0236feb7078e">